### PR TITLE
Modify Build Workflow and Badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,24 @@
-name: Build Document
+name: build
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
   push:
-    branches: [ main ]
 jobs:
   build-document:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout this repository
         uses: actions/checkout@v3
-      - name: Compile document
+
+      - name: Compile document in LaTeX
         uses: xu-cheng/latex-action@v2
         with:
           root_file: main.tex
-      - name: Save result
+
+      - name: Rename document
+        run: mv main.pdf paper.pdf
+
+      - name: Upload document as an artifact
         uses: actions/upload-artifact@v3
         with:
           name: document
-          path: main.pdf
+          path: paper.pdf

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![commits since latest version](https://img.shields.io/github/commits-since/b201lab/template-paper-ieee/latest)](https://github.com/b201lab/template-paper-ieee/commits/master)
 [![repo size](https://img.shields.io/github/repo-size/b201lab/template-paper-ieee)](https://github.com/b201lab/template-paper-ieee)
 [![license](https://img.shields.io/github/license/b201lab/template-paper-ieee)](./LICENSE)
-[![build document status](https://img.shields.io/github/workflow/status/b201lab/template-paper-ieee/Build%20Document)](https://github.com/b201lab/template-paper-ieee/actions)
+[![build status](https://img.shields.io/github/actions/workflow/status/b201lab/template-paper-ieee/build.yml?branch=main)](https://github.com/b201lab/template-paper-ieee/actions)
 
 Repositori ini berisi template [LaTeX](https://www.latex-project.org/) dari paper untuk konferensi yang diselenggarakan oleh [Institute of Electrical and Electronics Engineers](https://www.ieee.org/) (IEEE).
 Template yang ada pada repositori ini menggunakan format resmi [IEEETran](http://www.michaelshell.org/tex/ieeetran/) versi 1.8b yang dikeluarkan oleh IEEE.


### PR DESCRIPTION
- Modify `build-document.yml` workflow into `build.yml` workflow.
- Add [manual trigger](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) in the `build.yml` workflow.
- Rename output file artifact into `paper.pdf`.
- Modify and fix build badge URL as mentioned in https://github.com/badges/shields/issues/8671.